### PR TITLE
Fix db import by consolidating app factory

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,41 @@
+from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 from flask_migrate import Migrate
 from flask_restx import Api
 
+from .config import Config
+
 db = SQLAlchemy()
 jwt = JWTManager()
 migrate = Migrate()
-api = Api(version='1.0', title='TaskFlow API', description='A Trello-like backend API for TaskFlow')
+api = Api(
+    version="1.0",
+    title="TaskFlow API",
+    description="A Trello-like backend API for TaskFlow",
+)
+
+
+def create_app() -> Flask:
+    """Application factory for the TaskFlow API."""
+    app = Flask(__name__)
+    app.config.from_object(Config)
+
+    db.init_app(app)
+    jwt.init_app(app)
+    migrate.init_app(app, db)
+    api.init_app(app)
+
+    with app.app_context():
+        from .routes.auth import auth_ns
+        from .routes.board import board_ns
+        from .routes.list import list_ns
+        from .routes.card import card_ns
+
+        api.add_namespace(auth_ns, path="/api/auth")
+        api.add_namespace(board_ns, path="/api/boards")
+        api.add_namespace(list_ns, path="/api/lists")
+        api.add_namespace(card_ns, path="/api/cards")
+
+    return app
+

--- a/main.py
+++ b/main.py
@@ -1,39 +1,7 @@
 from flask import Flask, render_template
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
-from flask_jwt_extended import JWTManager
-from flask_restx import Api
-from app.config import Config
 
-db = SQLAlchemy()
-jwt = JWTManager()
-migrate = Migrate()
-api = Api(version='1.0', title='TaskFlow API', description='A Trello-like backend API for TaskFlow')
+from app import create_app
 
-def create_app():
-    # Create and configure the Flask app
-    app = Flask(__name__)
-    app.config.from_object(Config)
-
-    # Initialize extensions
-    db.init_app(app)
-    jwt.init_app(app)
-    migrate.init_app(app, db)
-    api.init_app(app)
-
-    # Import and register namespaces (routes)
-    with app.app_context():
-        from app.routes.auth import auth_ns
-        from app.routes.board import board_ns
-        from app.routes.list import list_ns
-        from app.routes.card import card_ns
-
-        api.add_namespace(auth_ns, path='/api/auth')
-        api.add_namespace(board_ns, path='/api/boards')
-        api.add_namespace(list_ns, path='/api/lists')
-        api.add_namespace(card_ns, path='/api/cards')
-
-    return app
 
 app = create_app()
 


### PR DESCRIPTION
## Summary
- move app factory logic into `app/__init__.py`
- simplify `main.py` to use the factory
- remove unused `app.py`

## Testing
- `python - <<'PY'
from app import create_app, db
app = create_app()
print('created', isinstance(app.config['SQLALCHEMY_DATABASE_URI'], str))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_685f4e6e903c8327834d369c519994a1